### PR TITLE
fix: resolve broken lightstep spans

### DIFF
--- a/src/proxy/main.py
+++ b/src/proxy/main.py
@@ -32,12 +32,20 @@ def span_factory(trace_id, span_id, start_time_unix_nano, end_time_unix_nano, st
     "resourceSpans": [
         {
             "resource": {
-                "attributes": [{
+                "attributes": [
+                {
                     "key": "environment",
                     "value": {
                         "stringValue": "localhost"
                     }
-                }]
+                },
+                {
+                    "key": "service.name",
+                    "value": {
+                        "stringValue": service_name
+                    }
+                }
+                ]
             },
             "instrumentationLibrarySpans": [{
                 "spans": [
@@ -70,13 +78,7 @@ def span_factory(trace_id, span_id, start_time_unix_nano, end_time_unix_nano, st
                             {
                                 "key": "name",
                                 "value": {
-                                    "stringValue": name 
-                                }
-                            }
-                            {
-                                "key": "service.name",
-                                "value": {
-                                    "stringValue": service_name,
+                                    "stringValue": name,
                                 }
                             }
                         ],


### PR DESCRIPTION
lightstep appears to reject traces missing the `service.name` property
as a span _resource_ attribute (error message = Invalid runtime in
Report (missing or empty component)).

This only appears to be an issue when sending via manually
instrumented OTLP/HTTP since the OpenTelemetry SDKs all add
this property by default.